### PR TITLE
PSMinUidGidとPSDefaultUidGidの値のチェックを追加

### DIFF
--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -63,6 +63,7 @@
 #include <grp.h>
 #include <sys/prctl.h>
 #include <sys/capability.h>
+#include <limits.h>
 
 #define MODULE_NAME "mod_process_security"
 #define MODULE_VERSION "1.0.0"
@@ -156,10 +157,23 @@ static const char *set_minuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
   if (err != NULL)
     return err;
 
-  // conf->min_uid = ap_uname2id(uid);
-  // conf->min_gid = ap_gname2id(gid);
-  conf->min_uid = (uid_t)atoi(uid);
-  conf->min_gid = (gid_t)atoi(gid);
+  unsigned long check_uid = (unsigned long)apr_atoi64(uid);
+
+  if(check_uid < 0 || check_uid > UINT_MAX){
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                 "%s ERROR %s:minuid of illegal value", MODULE_NAME, __func__);
+    return "minuid of illegal value";
+  }
+
+  unsigned long check_gid = (unsigned long)apr_atoi64(gid);
+  if(check_gid < 0 || check_gid > UINT_MAX){
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                 "%s ERROR %s:mingid of illegal value", MODULE_NAME, __func__);
+    return "mingid of illegal value";
+  }
+
+  conf->min_uid = (uid_t)check_uid;
+  conf->min_gid = (gid_t)check_gid;
 
   return NULL;
 }
@@ -175,10 +189,23 @@ static const char *set_defuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
   if (err != NULL)
     return err;
 
-  // conf->default_uid = ap_uname2id(uid);
-  // conf->default_gid = ap_gname2id(gid);
-  conf->default_uid = (uid_t)atoi(uid);
-  conf->default_gid = (gid_t)atoi(gid);
+  unsigned long check_uid = (unsigned long)apr_atoi64(uid);
+
+  if(check_uid < 0 || check_uid > UINT_MAX){
+      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                   "%s ERROR %s:defuid of illegal value", MODULE_NAME, __func__);
+      return "defuid of illegal value";
+  }
+
+  unsigned long check_gid = (unsigned long)apr_atoi64(gid);
+  if(check_gid < 0 || check_gid > UINT_MAX){
+       ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                   "%s ERROR %s:defgid of illegal value", MODULE_NAME, __func__);
+       return "defgid of illegal value";
+  }
+
+  conf->default_uid = (uid_t)check_uid;
+  conf->default_gid = (gid_t)check_gid;
 
   return NULL;
 }


### PR DESCRIPTION
設定ファイルに記述されるPSMinUidGidとPSDefaultUidGidの値のチェックを行う機能を追加するPRです。
設定ファイルの値はユーザが自由な値を設定する可能性があるため、unsigned intの最大値を超える値を設定すると値が値がオーバーフローします。

 * 再現方法

以下のような設定をmod_process_security.confに追記します。

```
PSMinUidGid 4294967296 100
```

この場合、psminuidは0として認識されます。

本PRをマージしたいただければ、上記のような設定をされた場合、エラーを出力し、httpdの起動を抑止します。

```
[root@localhost mod_process_security]# /usr/sbin/httpd
[Thu Aug 27 06:53:53 2015] [error] mod_process_security ERROR set_minuidgid:minuid of illegal value
Syntax error on line 1027 of /etc/httpd/conf/httpd.conf:
minuid of illegal value
```

以上です。よろしくおねがいいたします。

