### PR TITLE
modified check mechanism the value of the uid and gid

### DIFF
--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -159,14 +159,14 @@ static const char *set_minuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
 
   unsigned long check_uid = (unsigned long)apr_atoi64(uid);
 
-  if(check_uid < 0 || check_uid > UINT_MAX){
+  if(check_uid > UINT_MAX){
     ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
                  "%s ERROR %s:minuid of illegal value", MODULE_NAME, __func__);
     return "minuid of illegal value";
   }
 
   unsigned long check_gid = (unsigned long)apr_atoi64(gid);
-  if(check_gid < 0 || check_gid > UINT_MAX){
+  if(check_gid > UINT_MAX){
     ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
                  "%s ERROR %s:mingid of illegal value", MODULE_NAME, __func__);
     return "mingid of illegal value";
@@ -191,14 +191,14 @@ static const char *set_defuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
 
   unsigned long check_uid = (unsigned long)apr_atoi64(uid);
 
-  if(check_uid < 0 || check_uid > UINT_MAX){
+  if(check_uid > UINT_MAX){
       ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
                    "%s ERROR %s:defuid of illegal value", MODULE_NAME, __func__);
       return "defuid of illegal value";
   }
 
   unsigned long check_gid = (unsigned long)apr_atoi64(gid);
-  if(check_gid < 0 || check_gid > UINT_MAX){
+  if(check_gid > UINT_MAX){
        ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
                    "%s ERROR %s:defgid of illegal value", MODULE_NAME, __func__);
        return "defgid of illegal value";


### PR DESCRIPTION
以下のPRは適切に動作するが、unsigned intの値を0未満であるかの検査を行っていたため、clangで警告が発生していました。
https://github.com/matsumoto-r/mod_process_security/pull/5
0未満であるか否かのチェックを外しました。
これによりclangでの警告がなくなるとおもいます。

お手数ですがご確認をお願いします。