### PR TITLE
Support suexec check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     APR_UTIL_TAR=${APR_UTIL}.tar.gz 
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_process_security.conf.2.2"
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=prefork"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -504,10 +504,10 @@ static int process_security_handler(request_rec *r)
 
   // suexec ids check
   ugid = ap_run_get_suexec_identity(r);
-  if (dconf->check_suexec_ids == ON && ugid != NULL && ugid->uid != r->finfo.user) {                                              
-    ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,                                   
-        "%s ERROR %s: PSCheckSuexecids faild: opened r->filename=%s uid=%d but suexec config uid=%d"
-        MODULE_NAME, __func__, r->filename, r->finfo.user, ugid->uid);                        
+  if (dconf->check_suexec_ids == ON && ugid != NULL && (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group)) {
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+        "%s ERROR %s: PSCheckSuexecids faild: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
+        MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
     return HTTP_FORBIDDEN;                                                       
   }                                                                              
 

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -506,7 +506,7 @@ static int process_security_handler(request_rec *r)
   ugid = ap_run_get_suexec_identity(r);
   if (dconf->check_suexec_ids == ON && ugid != NULL && (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group)) {
     ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-        "%s ERROR %s: PSCheckSuexecids faild: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
+        "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
         MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
     return HTTP_FORBIDDEN;                                                       
   }                                                                              

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -38,7 +38,7 @@
 #include "http_log.h"
 #include "http_protocol.h"
 #include "http_request.h"
-#include "unixd.h"                                                               
+#include "unixd.h"
 #include "mpm_common.h"
 #include <sys/types.h>
 #include <unistd.h>
@@ -88,20 +88,20 @@ typedef struct {
 
 } process_security_config_t;
 
-typedef struct {                                                                 
+typedef struct {
 
-  u_int check_suexec_ids;                                                     
+  u_int check_suexec_ids;
 
-} process_security_dir_config_t;                                                              
-                                                                                 
-static void *ps_create_dir_config(apr_pool_t *p, char *d)                       
-{                                                                                
-  process_security_dir_config_t *dconf = apr_pcalloc(p, sizeof(process_security_dir_config_t));            
-                                                                                 
+} process_security_dir_config_t;
+
+static void *ps_create_dir_config(apr_pool_t *p, char *d)
+{
+  process_security_dir_config_t *dconf = apr_pcalloc(p, sizeof(process_security_dir_config_t));
+
   dconf->check_suexec_ids = OFF;
-                                                                                 
-  return dconf;                                                                  
-}                                                                                
+
+  return dconf;
+}
 
 module AP_MODULE_DECLARE_DATA process_security_module;
 
@@ -247,14 +247,14 @@ static const char *set_keep_open(cmd_parms *cmd, void *mconfig, int flag)
   return NULL;
 }
 
-static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)                                                                    
-{                                                                                
-    process_security_dir_config_t *dconf = (process_security_dir_config_t *)mconfig;
-                                                                                 
-    dconf->check_suexec_ids = flag;                                                  
-                                                                                 
-    return NULL;                                                                 
-}                                                                                
+static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)
+{
+  process_security_dir_config_t *dconf = (process_security_dir_config_t *)mconfig;
+
+  dconf->check_suexec_ids = flag;
+
+  return NULL;
+}
 
 static const char *set_extensions(cmd_parms *cmd, void *mconfig, const char *arg)
 {
@@ -464,7 +464,7 @@ static int process_security_handler(request_rec *r)
   int name_len = 0;
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
-  process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);                                                   
+  process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);
 
   // check a target file for process_security
   if (thread_on)
@@ -508,8 +508,8 @@ static int process_security_handler(request_rec *r)
     ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
         "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
         MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
-    return HTTP_FORBIDDEN;                                                       
-  }                                                                              
+    return HTTP_FORBIDDEN;
+  }
 
   apr_threadattr_create(&thread_attr, r->pool);
   apr_threadattr_detach_set(thread_attr, 0);
@@ -544,9 +544,9 @@ static const command_rec process_security_cmds[] = {
                  "Enable CAP_DAC_OVERRIDE of capabillity ON / Off. (default Off)"),
     AP_INIT_FLAG("PSKeepOpenFile", set_keep_open, NULL, ACCESS_CONF | RSRC_CONF,
                  "Enable keeping open file before handler for operation ON / Off. (default Off)"),
-    AP_INIT_FLAG("PSCheckSuexecids", set_check_suexec_ids, NULL,               
-        ACCESS_CONF | RSRC_CONF, "Set Enable Owner Check via suExecUserGgroup "  
-        " On / Off. (default Off)"),                                               
+    AP_INIT_FLAG("PSCheckSuexecids", set_check_suexec_ids, NULL, ACCESS_CONF | RSRC_CONF,
+                 "Set Enable Owner Check via suExecUserGgroup "
+                 " On / Off. (default Off)"),
     AP_INIT_TAKE2("PSMinUidGid", set_minuidgid, NULL, RSRC_CONF, "Minimal uid and gid."),
     AP_INIT_TAKE2("PSDefaultUidGid", set_defuidgid, NULL, RSRC_CONF, "Default uid and gid."),
     AP_INIT_ITERATE("PSExtensions", set_extensions, NULL, ACCESS_CONF | RSRC_CONF, "Set Enable Extensions."),
@@ -567,11 +567,10 @@ AP_DECLARE_MODULE(process_security) = {
 #else
 module AP_MODULE_DECLARE_DATA process_security_module = {
 #endif
-    STANDARD20_MODULE_STUFF,
-    ps_create_dir_config,          /* dir config creater */
-    NULL,                          /* dir merger */
-    create_config,                 /* server config */
-    NULL,                          /* merge server config */
-    process_security_cmds,         /* command apr_table_t */
-    register_hooks                 /* register hooks */
+    STANDARD20_MODULE_STUFF, ps_create_dir_config, /* dir config creater */
+    NULL,                                          /* dir merger */
+    create_config,                                 /* server config */
+    NULL,                                          /* merge server config */
+    process_security_cmds,                         /* command apr_table_t */
+    register_hooks                                 /* register hooks */
 };

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -38,6 +38,7 @@
 #include "http_log.h"
 #include "http_protocol.h"
 #include "http_request.h"
+#include "unixd.h"                                                               
 #include "mpm_common.h"
 #include <sys/types.h>
 #include <unistd.h>
@@ -86,6 +87,21 @@ typedef struct {
   apr_array_header_t *ignore_extensions;
 
 } process_security_config_t;
+
+typedef struct {                                                                 
+
+  u_int check_suexec_ids;                                                     
+
+} process_security_dir_config_t;                                                              
+                                                                                 
+static void *ps_create_dir_config(apr_pool_t *p, char *d)                       
+{                                                                                
+  process_security_dir_config_t *dconf = apr_pcalloc(p, sizeof(process_security_dir_config_t));            
+                                                                                 
+  dconf->check_suexec_ids = OFF;
+                                                                                 
+  return dconf;                                                                  
+}                                                                                
 
 module AP_MODULE_DECLARE_DATA process_security_module;
 
@@ -230,6 +246,15 @@ static const char *set_keep_open(cmd_parms *cmd, void *mconfig, int flag)
 
   return NULL;
 }
+
+static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)                                                                    
+{                                                                                
+    process_security_dir_config_t *dconf = (process_security_dir_config_t *)mconfig;
+                                                                                 
+    dconf->check_suexec_ids = flag;                                                  
+                                                                                 
+    return NULL;                                                                 
+}                                                                                
 
 static const char *set_extensions(cmd_parms *cmd, void *mconfig, const char *arg)
 {
@@ -433,11 +458,13 @@ static int process_security_handler(request_rec *r)
   apr_threadattr_t *thread_attr;
   apr_thread_t *thread;
   apr_status_t status, thread_status;
+  ap_unix_identity_t *ugid;
 
   int enable = 0;
   int name_len = 0;
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
+  process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);                                                   
 
   // check a target file for process_security
   if (thread_on)
@@ -475,6 +502,15 @@ static int process_security_handler(request_rec *r)
   if (!enable)
     return DECLINED;
 
+  // suexec ids check
+  ugid = ap_run_get_suexec_identity(r);
+  if (dconf->check_suexec_ids == ON && ugid != NULL && ugid->uid != r->finfo.user) {                                              
+    ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,                                   
+        "%s ERROR %s: PSCheckSuexecids faild: opened r->filename=%s uid=%d but suexec config uid=%d"
+        MODULE_NAME, __func__, r->filename, r->finfo.user, ugid->uid);                        
+    return HTTP_FORBIDDEN;                                                       
+  }                                                                              
+
   apr_threadattr_create(&thread_attr, r->pool);
   apr_threadattr_detach_set(thread_attr, 0);
 
@@ -508,6 +544,9 @@ static const command_rec process_security_cmds[] = {
                  "Enable CAP_DAC_OVERRIDE of capabillity ON / Off. (default Off)"),
     AP_INIT_FLAG("PSKeepOpenFile", set_keep_open, NULL, ACCESS_CONF | RSRC_CONF,
                  "Enable keeping open file before handler for operation ON / Off. (default Off)"),
+    AP_INIT_FLAG("PSCheckSuexecids", set_check_suexec_ids, NULL,               
+        ACCESS_CONF | RSRC_CONF, "Set Enable Owner Check via suExecUserGgroup "  
+        " On / Off. (default Off)"),                                               
     AP_INIT_TAKE2("PSMinUidGid", set_minuidgid, NULL, RSRC_CONF, "Minimal uid and gid."),
     AP_INIT_TAKE2("PSDefaultUidGid", set_defuidgid, NULL, RSRC_CONF, "Default uid and gid."),
     AP_INIT_ITERATE("PSExtensions", set_extensions, NULL, ACCESS_CONF | RSRC_CONF, "Set Enable Extensions."),
@@ -528,7 +567,8 @@ AP_DECLARE_MODULE(process_security) = {
 #else
 module AP_MODULE_DECLARE_DATA process_security_module = {
 #endif
-    STANDARD20_MODULE_STUFF, NULL, /* dir config creater */
+    STANDARD20_MODULE_STUFF,
+    ps_create_dir_config,          /* dir config creater */
     NULL,                          /* dir merger */
     create_config,                 /* server config */
     NULL,                          /* merge server config */


### PR DESCRIPTION
mod_process_security supports suexec ids check feature which check file owner/group with `SuexecUserGroup` values.

```apache
<Directory /usr/local/apache/htdocs/blog>
  PSCheckSuexecids ON
</Directory>
```

```apache
<VirtualHost 127.0.0.1:8080>
  DocumentRoot /usr/local/apache/htdocs/blog
  SuexecUserGroup matsumoto_r matsumoto_r
</VirtualHost>
```

- OK
```
-rw-r--r-- 1 matsumoto_r matsumoto_r 418 11月  8 01:05 2013 /usr/local/apache/htdocs/blog/index.php
```

- NG
```
-rw-r--r-- 1 matsumoto_r daemon 418 11月  8 01:05 2013 /usr/local/apache/htdocs/blog/index.php
```

- NG
```
-rw-r--r-- 1 daemon matsumoto_r 418 11月  8 01:05 2013 /usr/local/apache/htdocs/blog/index.php
```

- NG
```
-rw-r--r-- 1 daemon daemon 418 11月  8 01:05 2013 /usr/local/apache/htdocs/blog/index.php
```

- error_log
```
[Fri Oct 23 14:44:28.962022 2015] [process_security:error] [pid 27378] mod_process_security ERROR process_security_handler: PSCheckSuexecids faild: opened r->filename=/usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php uid=500 gid=500 but suexec config uid=2 gid=500
[Fri Oct 23 14:43:50.554090 2015] [process_security:error] [pid 27329] mod_process_security ERROR process_security_handler: PSCheckSuexecids faild: opened r->filename=/usr/local/apache/htdocs/blog/index.php uid=500 gid=500 but suexec config uid=500 gid=2
```