### PR TITLE
[WIP]mod_process_securityのwebdav対応

### DIFF
--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -358,7 +358,6 @@ static const char *set_ignore_extensions(cmd_parms *cmd, void *mconfig, const ch
 }
 
 static int process_security_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
-{
   ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_init start");
   void *data;
   const char *userdata_key = "process_security_init";
@@ -377,7 +376,6 @@ static int process_security_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *pt
 
 static void process_security_child_init(apr_pool_t *p, server_rec *server)
 {
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_child_init start");
   int ncap;
   cap_t cap;
   cap_value_t capval[3];
@@ -405,7 +403,6 @@ static void process_security_child_init(apr_pool_t *p, server_rec *server)
 
 static int process_security_set_cap(request_rec *r)
 {
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_set_cap start");
   int ncap;
   cap_t cap;
   cap_value_t capval[3];
@@ -490,7 +487,6 @@ static int process_security_set_cap(request_rec *r)
 
 static void *APR_THREAD_FUNC process_security_thread_handler(apr_thread_t *thread, void *data)
 {
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_thread_handler start");
   request_rec *r = (request_rec *)data;
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   int result;
@@ -523,7 +519,6 @@ static void *APR_THREAD_FUNC process_security_thread_handler(apr_thread_t *threa
 
 static int process_security_handler(request_rec *r)
 {
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_handler start");
   int i;
   const char *extension, *handler;
   apr_threadattr_t *thread_attr;
@@ -535,10 +530,6 @@ static int process_security_handler(request_rec *r)
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);
-
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "PSDavEnable : %d", conf->psdav_enable);
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "DAV_DETECT : %d", conf->dav_detect);
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "PSDavUidGid : %d:%d", conf->dav_uid, conf->dav_gid);
 
   // check a target file for process_security
   if (thread_on)

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -135,8 +135,8 @@ static void *create_config(apr_pool_t *p, server_rec *s)
   conf->cap_dac_override_enable = OFF;
   conf->keep_open_enable = OFF;
   conf->psdav_enable = OFF;
-  conf->dav_uid = PS_DEFAULT_UID;
-  conf->dav_gid = PS_DEFAULT_GID;
+  conf->dav_uid = -1;
+  conf->dav_gid = -1;
   conf->extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->handlers = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->ignore_extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
@@ -417,6 +417,10 @@ static int process_security_set_cap(request_rec *r)
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
 
   if(conf->psdav_enable && dav_get_provider(r)){
+     if(conf->dav_gid < 0 || conf->dav_uid < 0){
+         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "The webdav mode requires psdavuidgid parameters.");
+         return -1;
+     }
      gid = conf->dav_gid;
      uid = conf->dav_uid;
   }else{

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -82,6 +82,8 @@ typedef struct {
   gid_t default_gid;
   uid_t min_uid;
   gid_t min_gid;
+  u_int psdav_enable;
+  u_int dav_detect;
   apr_array_header_t *extensions;
   apr_array_header_t *handlers;
   apr_array_header_t *ignore_extensions;
@@ -121,6 +123,8 @@ static void *create_config(apr_pool_t *p, server_rec *s)
   conf->root_enable = OFF;
   conf->cap_dac_override_enable = OFF;
   conf->keep_open_enable = OFF;
+  conf->psdav_enable = OFF;
+  conf->dav_detect = OFF;
   conf->extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->handlers = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->ignore_extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
@@ -252,6 +256,33 @@ static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)
   process_security_dir_config_t *dconf = (process_security_dir_config_t *)mconfig;
 
   dconf->check_suexec_ids = flag;
+
+  return NULL;
+}
+
+
+static const char *set_psdav_enable(cmd_parms *cmd, void *mconfig, int flag)
+{
+  process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+  const char *err = ap_check_cmd_context(cmd, NOT_IN_FILES | NOT_IN_LIMIT);
+
+  if (err != NULL)
+    return err;
+
+  conf->psdav_enable = flag;
+
+  return NULL;
+}
+
+static const char *set_dav_detect(cmd_parms *cmd, void *mconfig, int flag)
+{
+  process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+  const char *err = ap_check_cmd_context(cmd, NOT_IN_FILES | NOT_IN_LIMIT);
+
+  if (err != NULL)
+    return err;
+
+  conf->dav_detect = flag;
 
   return NULL;
 }
@@ -465,6 +496,9 @@ static int process_security_handler(request_rec *r)
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);
 
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "PSDavEnable : %d", conf->psdav_enable);
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "DAV_DETECT : %d", conf->dav_detect);
+
   // check a target file for process_security
   if (thread_on)
     return DECLINED;
@@ -554,6 +588,10 @@ static const command_rec process_security_cmds[] = {
     AP_INIT_FLAG("PSCheckSuexecids", set_check_suexec_ids, NULL, ACCESS_CONF | RSRC_CONF,
                  "Set Enable Owner Check via suExecUserGgroup "
                  " On / Off. (default Off)"),
+    AP_INIT_FLAG("PSDavEnable", set_psdav_enable, NULL, ACCESS_CONF | RSRC_CONF,
+                 "Set Enable working of considering webdav  On / Off. (default Off)"),
+    AP_INIT_FLAG("DAV", set_dav_detect, NULL, ACCESS_CONF | RSRC_CONF,
+                 "detection of DAV option of mod_dav. (user don't touch this option)"),
     AP_INIT_TAKE2("PSMinUidGid", set_minuidgid, NULL, RSRC_CONF, "Minimal uid and gid."),
     AP_INIT_TAKE2("PSDefaultUidGid", set_defuidgid, NULL, RSRC_CONF, "Default uid and gid."),
     AP_INIT_ITERATE("PSExtensions", set_extensions, NULL, ACCESS_CONF | RSRC_CONF, "Set Enable Extensions."),

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -538,6 +538,11 @@ static int process_security_handler(request_rec *r)
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);
 
+  if(conf->psdav_enable && dconf->check_suexec_ids){
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "PSDavEnable and PSCheckSuexecids can not be used simultaneously");
+    return HTTP_INTERNAL_SERVER_ERROR;
+  }
+
   // check a target file for process_security
   if (thread_on)
     return DECLINED;

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -416,8 +416,13 @@ static int process_security_set_cap(request_rec *r)
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
 
-  gid = r->finfo.group;
-  uid = r->finfo.user;
+  if(conf->psdav_enable && conf->dav_detect){
+     gid = conf->dav_gid;
+     uid = conf->dav_uid;
+  }else{
+     gid = r->finfo.group;
+     uid = r->finfo.user;
+  }
 
   if (!conf->root_enable && (uid == 0 || gid == 0)) {
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "%s NOTICE %s: permission of %s is root, can't run the file",
@@ -539,7 +544,7 @@ static int process_security_handler(request_rec *r)
   if (thread_on)
     return DECLINED;
 
-  if (r->finfo.filetype == APR_NOFILE)
+  if (r->finfo.filetype == APR_NOFILE && !(conf->psdav_enable && conf->dav_detect))
     return DECLINED;
 
   if (conf->all_ext_enable) {

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -359,6 +359,7 @@ static const char *set_ignore_extensions(cmd_parms *cmd, void *mconfig, const ch
 
 static int process_security_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_init start");
   void *data;
   const char *userdata_key = "process_security_init";
 
@@ -376,6 +377,7 @@ static int process_security_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *pt
 
 static void process_security_child_init(apr_pool_t *p, server_rec *server)
 {
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_child_init start");
   int ncap;
   cap_t cap;
   cap_value_t capval[3];
@@ -403,7 +405,7 @@ static void process_security_child_init(apr_pool_t *p, server_rec *server)
 
 static int process_security_set_cap(request_rec *r)
 {
-
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_set_cap start");
   int ncap;
   cap_t cap;
   cap_value_t capval[3];
@@ -483,6 +485,7 @@ static int process_security_set_cap(request_rec *r)
 
 static void *APR_THREAD_FUNC process_security_thread_handler(apr_thread_t *thread, void *data)
 {
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_thread_handler start");
   request_rec *r = (request_rec *)data;
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   int result;
@@ -515,6 +518,7 @@ static void *APR_THREAD_FUNC process_security_thread_handler(apr_thread_t *threa
 
 static int process_security_handler(request_rec *r)
 {
+  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_handler start");
   int i;
   const char *extension, *handler;
   apr_threadattr_t *thread_attr;

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -358,7 +358,7 @@ static const char *set_ignore_extensions(cmd_parms *cmd, void *mconfig, const ch
 }
 
 static int process_security_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
-  ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "process_security_init start");
+{
   void *data;
   const char *userdata_key = "process_security_init";
 

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -538,57 +538,60 @@ static int process_security_handler(request_rec *r)
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
   process_security_dir_config_t *dconf = ap_get_module_config(r->per_dir_config, &process_security_module);
 
-  // check a target file for process_security
   if (thread_on)
     return DECLINED;
 
-  if (r->finfo.filetype == APR_NOFILE && (conf->psdav_enable == OFF || dav_get_provider(r) == NULL))
-    return DECLINED;
+  // check a target file for process_security on standard mode
 
-  if (conf->all_ext_enable) {
-    enable = ON;
-    for (i = 0; i < conf->ignore_extensions->nelts; i++) {
-      extension = ((char **)conf->ignore_extensions->elts)[i];
-      name_len = strlen(r->filename) - strlen(extension);
-      if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
-        enable = OFF;
-    }
-  } else {
-    for (i = 0; i < conf->extensions->nelts; i++) {
-      extension = ((char **)conf->extensions->elts)[i];
-      name_len = strlen(r->filename) - strlen(extension);
-      if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
+  if(conf->psdav_enable == OFF || dav_get_provider(r) == NULL){
+     if (r->finfo.filetype == APR_NOFILE)
+        return DECLINED;
+
+     if (conf->all_ext_enable) {
         enable = ON;
-    }
-    // check handler
-    for (i = 0; i < conf->handlers->nelts; i++) {
-      handler = ((char **)conf->handlers->elts)[i];
-      if (strcmp(r->handler, handler) == 0)
+        for (i = 0; i < conf->ignore_extensions->nelts; i++) {
+           extension = ((char **)conf->ignore_extensions->elts)[i];
+           name_len = strlen(r->filename) - strlen(extension);
+           if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
+              enable = OFF;
+        }
+     } else {
+        for (i = 0; i < conf->extensions->nelts; i++) {
+           extension = ((char **)conf->extensions->elts)[i];
+           name_len = strlen(r->filename) - strlen(extension);
+           if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
+              enable = ON;
+        }
+        // check handler
+        for (i = 0; i < conf->handlers->nelts; i++) {
+           handler = ((char **)conf->handlers->elts)[i];
+           if (strcmp(r->handler, handler) == 0)
+              enable = ON;
+        }
+     }
+
+     if (conf->all_cgi_enable && strcmp(r->handler, "cgi-script") == 0)
         enable = ON;
-    }
-  }
 
-  if (conf->all_cgi_enable && strcmp(r->handler, "cgi-script") == 0)
-    enable = ON;
+     if (!enable)
+        return DECLINED;
 
-  if (!enable)
-    return DECLINED;
-
-  // suexec ids check
-  if (dconf->check_suexec_ids == ON && conf->psdav_enable == OFF) {
-    ap_unix_identity_t *ugid = ap_run_get_suexec_identity(r);
-    if (ugid == NULL) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-          "%s ERROR %s: PSCheckSuexecids failed return 500: ap_run_get_suexec_identity() is NULL or not found SuexecUserGroup",
-          MODULE_NAME, __func__);
-      return HTTP_INTERNAL_SERVER_ERROR;
-    }
-    if (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-          "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
-          MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
-      return HTTP_FORBIDDEN;
-    }
+     // suexec ids check
+     if (dconf->check_suexec_ids == ON && conf->psdav_enable == OFF) {
+        ap_unix_identity_t *ugid = ap_run_get_suexec_identity(r);
+        if (ugid == NULL) {
+           ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                 "%s ERROR %s: PSCheckSuexecids failed return 500: ap_run_get_suexec_identity() is NULL or not found SuexecUserGroup",
+                 MODULE_NAME, __func__);
+           return HTTP_INTERNAL_SERVER_ERROR;
+        }
+        if (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group) {
+           ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
+                 "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
+                 MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
+           return HTTP_FORBIDDEN;
+        }
+     }
   }
 
   apr_threadattr_create(&thread_attr, r->pool);


### PR DESCRIPTION
# チェック処理の修正
mod_davはmod_process_securityと同じく、ap_hook_handlerのタイミングで主な処理を行います。mod_process_securityはap_hook_handlerのAPR_HOOK_REALLY_FIRSTで動くので、webdavも基本的に対応できるはずですが、以下のステートメントのチェックによりwebdavとmod_process_securityは共存できなくなっていました。
```
-  if (r->finfo.filetype == APR_NOFILE)
```
そこで上記チェックをwebdav併用時にのみチェックするような修正を行いました。

# オプションの追加

mod_process_securityとmod_davの併用を明記するためにPSDavEnableとmod_davが稼働していることを検知するためのDavDetectionと言うオプションを追記しました。
またmod_davが稼働するディレクティブの権限を指定するために、PSDavUidGidと言うオプションも付与しています。

# Apacheの設定例

```
<VirtualHost *:80>
<IfModule mod_process_security.c>
PSExAll On
PSDavEnable On
PSDavUidGid 1001 1001
</IfModule>

ServerAdmin webmaster@localhost
DocumentRoot /var/www/webdav
ServerName mps-webdav.net
DAVLockDB /var/www/webdav/.dav

<Directory /var/www/webdav>
Require all granted
DAV On
</Directory>

</VirtualHost>
```

