### PR TITLE
mod_process_securityのwebdav対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ script:
 
   # upload uid,gid check script from webdav
   - curl --upload ./test/userinfo.cgi http://mps-webdav.test:8080
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/userinfo.cgi) = \"1003:1003\" ];then true;else false;fi"
 
   # add execute permisson
   - sudo chmod u+x /usr/local/apache2/webdav/userinfo.cgi
@@ -149,6 +150,7 @@ script:
   # MKCOL test
   - curl -X MKCOL http://mps-webdav.test:8080/MKCOL/
   - "if [ -d /usr/local/apache2/webdav/MKCOL/ ]; then true; else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/MKCOL/) = \"1003:1003\" ];then true;else false;fi"
 
   # DELETE directory in the webdav
   - curl -X DELETE http://mps-webdav.test:8080/MKCOL/
@@ -159,6 +161,9 @@ script:
   - curl -i -X LOCK --data @./test/lock.xml http://mps-webdav.test:8080/test.txt -o /tmp/LOCK
   - cat /tmp/LOCK
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
+  
+  # .dav owner and group test
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav/) = \"1003:1003\" ];then true;else false;fi"
 
   # Check LOCKED 
   - "echo 'abcdefg' > test.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav.dir/) = \"1004:1004\" ];then true;else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 
   - "echo 'abcdefg' > test.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav/) = \"1004:1004\" ];then true;else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav.dir/) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 
   - "echo 'abcdefg' > test.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
-  - sudo ls -al /usr/local/apach2/webdav/
+  - sudo ls -al /usr/local/apache2/webdav/
   - "if [ $(sudo stat -c '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ script:
 
   # upload uid,gid check script from webdav
   - curl --upload ./test/userinfo.cgi http://mps-webdav.test:8080
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/userinfo.cgi) = \"1004:1004\" ];then true;else false;fi"
+  - "if [ $(sudo stat -c '%u:%g' /usr/local/apache2/webdav/userinfo.cgi) = \"1004:1004\" ];then true;else false;fi"
 
   # add execute permisson
   - sudo chmod u+x /usr/local/apache2/webdav/userinfo.cgi
@@ -150,7 +150,7 @@ script:
   # MKCOL test
   - curl -X MKCOL http://mps-webdav.test:8080/MKCOL/
   - "if [ -d /usr/local/apache2/webdav/MKCOL/ ]; then true; else false;fi"
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/MKCOL/) = \"1004:1004\" ];then true;else false;fi"
+  - "if [ $(sudo stat -c '%u:%g' /usr/local/apache2/webdav/MKCOL/) = \"1004:1004\" ];then true;else false;fi"
 
   # DELETE directory in the webdav
   - curl -X DELETE http://mps-webdav.test:8080/MKCOL/
@@ -164,7 +164,7 @@ script:
   
   # .dav owner and group test
   - ls -al /usr/local/apach2/webdav/
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
+  - "if [ $(sudo stat -c '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 
   - "echo 'abcdefg' > test.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,6 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
+  - ls -al /usr/local/apach2/webdav/
   - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,13 @@ script:
 
   # debug
   - sudo cat $(../${HTTPD_VERSION}/apache/bin/apxs -q exp_logfiledir)/error_log
+
+  # build mruby
+  - cd test && git clone --depth=1 git://github.com/mruby/mruby.git
+  - cd mruby && MRUBY_CONFIG=../build_config.rb rake
+
+  # run test.rb
+  - cd ../
+  - ./mruby/bin/mruby ./test.rb
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ script:
   - curl http://mps-normal.test:8080/userinfo.cgi
   - curl http://mps-normal.test:8080/userinfo.cgi -o /tmp/userinfo.txt
   - cat /tmp/userinfo.txt
-  - "if [ $(cat /tmp/userinfo.txt) = \"1003:1003\" ];then true;else false;fi"
+  - "if [ $(cat /tmp/userinfo.txt) = \"1003:1003:1003:1003\" ];then true;else false;fi"
 
   # WRITE file to webdav 
   - echo 'mps-webdav-test' | tee -a test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ script:
 
   # upload uid,gid check script from webdav
   - curl --upload ./test/userinfo.cgi http://mps-webdav.test:8080
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/userinfo.cgi) = \"1003:1003\" ];then true;else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/userinfo.cgi) = \"1004:1004\" ];then true;else false;fi"
 
   # add execute permisson
   - sudo chmod u+x /usr/local/apache2/webdav/userinfo.cgi
@@ -128,7 +128,7 @@ script:
   - curl http://mps-normal.test:8080/userinfo.cgi
   - curl http://mps-normal.test:8080/userinfo.cgi -o /tmp/userinfo.txt
   - cat /tmp/userinfo.txt
-  - "if [ $(cat /tmp/userinfo.txt) = \"1003:1003:1003:1003\" ];then true;else false;fi"
+  - "if [ $(cat /tmp/userinfo.txt) = \"1004:1004:1004:1004\" ];then true;else false;fi"
 
   # WRITE file to webdav 
   - echo 'mps-webdav-test' | tee -a test.txt
@@ -150,7 +150,7 @@ script:
   # MKCOL test
   - curl -X MKCOL http://mps-webdav.test:8080/MKCOL/
   - "if [ -d /usr/local/apache2/webdav/MKCOL/ ]; then true; else false;fi"
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/MKCOL/) = \"1003:1003\" ];then true;else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/MKCOL/) = \"1004:1004\" ];then true;else false;fi"
 
   # DELETE directory in the webdav
   - curl -X DELETE http://mps-webdav.test:8080/MKCOL/
@@ -163,7 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
-  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav/) = \"1003:1003\" ];then true;else false;fi"
+  - "if [ $(stat -f '%u:%g' /usr/local/apache2/webdav/.dav/) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 
   - "echo 'abcdefg' > test.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     VHOST_CONF="test/mod_process_security.conf.2.2"
     VHOST_DAV_CONF="test/mod_process_security.dav.conf.2.2"
     DEFAULT_DIR="/home/travis/build/matsumoto-r/mod_process_security/"
-  - HTTPD_VERSION=httpd-2.4.17 
+  - HTTPD_VERSION=httpd-2.4.18 
     HTTPD_CONFIG_OPT="--with-mpm=prefork"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
   - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
   
   # .dav owner and group test
-  - ls -al /usr/local/apach2/webdav/
+  - sudo ls -al /usr/local/apach2/webdav/
   - "if [ $(sudo stat -c '%u:%g' /usr/local/apache2/webdav/.dav.dir) = \"1004:1004\" ];then true;else false;fi"
 
   # Check LOCKED 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
 before_install:
   - sudo apt-get -qq update
 install:
-  - sudo apt-get -qq install rake bison libcurl4-openssl-dev libhiredis-dev libmarkdown2-dev libapr1-dev libaprutil1-dev apache2 libcap-dev
+  - sudo apt-get -qq install rake bison libcurl4-openssl-dev libhiredis-dev libmarkdown2-dev libapr1-dev libaprutil1-dev apache2 libcap-dev curl
 env:
   - HTTPD_VERSION=httpd-2.2.31
     HTTPD_CONFIG_OPT="--with-mpm=prefork --enable-module=all --enable-mods-shared=all"
@@ -15,6 +15,8 @@ env:
     APR_UTIL_TAR=${APR_UTIL}.tar.gz 
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_process_security.conf.2.2"
+    VHOST_DAV_CONF="test/mod_process_security.dav.conf.2.2"
+    DEFAULT_DIR="/home/travis/build/matsumoto-r/mod_process_security/"
   - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=prefork"
     APR=apr-1.5.2 
@@ -24,6 +26,9 @@ env:
     APR_UTIL_TAR=${APR_UTIL}.tar.gz 
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_process_security.conf.2.4"
+    VHOST_DAV_CONF="test/mod_process_security.dav.conf.2.4"
+    DEFAULT_DIR="/home/travis/build/matsumoto-r/mod_process_security/"
+  #- HTTPD_VERSION=httpd-2.4.17 
 before_script:
   - cd ../
   - wget http://ftp.jaist.ac.jp/pub/apache//httpd/${HTTPD_TAR}
@@ -52,6 +57,9 @@ before_script:
   - sudo chmod 700 test/id2.cgi
   - sudo cp -p test/id2.cgi $(../${HTTPD_VERSION}/apache/bin/apxs -q exp_cgidir)/.
 
+  # backup default server config
+  - sudo cp $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf /tmp/
+
   # setup server config
   - sudo sed -i "s/^Listen/#Listen/" $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
   - sudo cat ${VHOST_CONF} >> $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
@@ -59,6 +67,7 @@ before_script:
   - sudo make APXS=../${HTTPD_VERSION}/apache/bin/apxs APACHECTL=../${HTTPD_VERSION}/apache/bin/apachectl restart
 script:
   # debug
+  - pwd
   - sudo ls -la $(../${HTTPD_VERSION}/apache/bin/apxs -q exp_cgidir)/
   - sudo netstat -lnpt
   - sudo cat $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
@@ -73,8 +82,105 @@ script:
   - cd test && git clone --depth=1 git://github.com/mruby/mruby.git
   - cd mruby && MRUBY_CONFIG=../build_config.rb rake
 
+  #--------------------#
+  # General Test Suite #
+  #--------------------#
+
   # run test.rb
-  - cd ../
+  - cd ${DEFAULT_DIR}/test 
   - ./mruby/bin/mruby ./test.rb
 
+  #-------------------#
+  # Webdav Test Suite #
+  #-------------------#
+  - cd ${DEFAULT_DIR}/
+  
+  # restore default config
+  - cp /tmp/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
+
+  # create webdav user
+  - sudo useradd webdav
+  - id webdav
+  
+  # cearete webdav directory
+  - sudo mkdir -p /usr/local/apache2/webdav/
+  - sudo chown -R webdav:webdav /usr/local/apache2/webdav/
+
+  # setup webdav config
+  - sudo sed -i "s/^Listen/#Listen/" $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
+  - sudo cat ${VHOST_DAV_CONF} >> $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
+  - sudo cat $(../${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir)/$(../${HTTPD_VERSION}/apache/bin/apxs -q progname).conf
+  - sudo make APXS=../${HTTPD_VERSION}/apache/bin/apxs APACHECTL=../${HTTPD_VERSION}/apache/bin/apachectl restart
+  - sudo cat $(../${HTTPD_VERSION}/apache/bin/apxs -q exp_logfiledir)/error_log
+  - echo '127.0.0.1 mps-normal.test' | sudo tee -a /etc/hosts
+  - echo '127.0.0.1 mps-webdav.test' | sudo tee -a /etc/hosts
+  - cat /etc/hosts
+  - sudo netstat -lnpt
+
+  # upload uid,gid check script from webdav
+  - curl --upload ./test/userinfo.cgi http://mps-webdav.test:8080
+
+  # add execute permisson
+  - sudo chmod u+x /usr/local/apache2/webdav/userinfo.cgi
+
+  # check uid,gid from cgi
+  - curl http://mps-normal.test:8080/userinfo.cgi
+  - curl http://mps-normal.test:8080/userinfo.cgi -o /tmp/userinfo.txt
+  - cat /tmp/userinfo.txt
+  - "if [ $(cat /tmp/userinfo.txt) = \"1003:1003\" ];then true;else false;fi"
+
+  # WRITE file to webdav 
+  - echo 'mps-webdav-test' | tee -a test.txt
+  - curl --upload test.txt http://mps-webdav.test:8080  
+
+  # READ file from webdav
+  - curl http://mps-webdav.test:8080/test.txt -o /tmp/test.txt
+  - "if [ $(cat /tmp/test.txt) = \"mps-webdav-test\" ];then true;else false;fi"
+
+  # DELETE file in the webdav
+  - curl -X DELETE http://mps-webdav.test:8080/test.txt
+  - "if [ ! -f /usr/local/apache2/webdav/test.txt ]; then true; else false;fi"
+
+  # PROPFIND test
+  - curl -X PROPFIND http://mps-webdav.test:8080/userinfo.cgi -o /tmp/PROPFIND
+  - cat /tmp/PROPFIND
+  - "if [ $(file /tmp/PROPFIND | grep 'XML document text' -c ) = 1 ]; then true; else false;fi"
+
+  # MKCOL test
+  - curl -X MKCOL http://mps-webdav.test:8080/MKCOL/
+  - "if [ -d /usr/local/apache2/webdav/MKCOL/ ]; then true; else false;fi"
+
+  # DELETE directory in the webdav
+  - curl -X DELETE http://mps-webdav.test:8080/MKCOL/
+  - "if [ ! -d /usr/local/apache2/webdav/MKCOL/ ]; then true; else false;fi"
+
+  # LOCK test
+  - curl --upload test.txt http://mps-webdav.test:8080  
+  - curl -i -X LOCK --data @./test/lock.xml http://mps-webdav.test:8080/test.txt -o /tmp/LOCK
+  - cat /tmp/LOCK
+  - "if [ $(cat /tmp/LOCK | grep 'Lock-Token' -c ) = 1 ]; then true; else false;fi"
+
+  # Check LOCKED 
+  - "echo 'abcdefg' > test.txt"
+  - curl http://mps-webdav.test:8080/test.txt -o /tmp/LOCK01
+  - cat /tmp/LOCK01
+  - curl --upload test.txt http://mps-webdav.test:8080 -o /tmp/UPLOAD_ON_LOCK
+  - "if [ $(cat /tmp/UPLOAD_ON_LOCK | grep '423 Locked' -c ) = 1 ]; then true; else false;fi"
+  - curl http://mps-webdav.test:8080/test.txt -o /tmp/LOCK02
+  - cat /tmp/LOCK02
+  - "if cmp /tmp/LOCK01 /tmp/LOCK02; then true; else false;fi"
+
+  # UNLOCK test
+  - cat /tmp/LOCK |grep 'Lock-Token' | perl -nle '@a = split(":", $_, 2); chomp $a[1]; $a[1] =~ s/\s//g; print $a[1];' > /tmp/TOKEN
+  - cat /tmp/TOKEN
+  - cat /tmp/TOKEN | xargs -I {} curl -i -X UNLOCK --header 'Lock-Token:{}' http://mps-webdav.test:8080/test.txt -o /tmp/UNLOCK
+  - cat /tmp/UNLOCK
+
+  # Check UNLOCKED
+  - curl http://mps-webdav.test:8080/test.txt -o /tmp/UNLOCK01
+  - cat /tmp/UNLOCK01
+  - curl --upload test.txt http://mps-webdav.test:8080
+  - curl http://mps-webdav.test:8080/test.txt -o /tmp/UNLOCK02
+  - cat /tmp/UNLOCK02
+  - "if ! cmp /tmp/UNLOCK01 /tmp/UNLOCK02; then true; else false;fi"
 

--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ stop:
 	$(APACHECTL) -k stop
 
 test:
-	cd test/ && git clone --depth=1 git://github.com/mruby/mruby.git
-	cd test/mruby && MRUBY_CONFIG=../build_config.rb rake
-	cd test/ && ./mruby/bin/mruby test.rb
+	/bin/true
 
 .PHONY: test
 

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -82,6 +82,7 @@ typedef struct {
   gid_t default_gid;
   uid_t min_uid;
   gid_t min_gid;
+  u_int psdav_enable;
   apr_array_header_t *extensions;
   apr_array_header_t *handlers;
   apr_array_header_t *ignore_extensions;
@@ -121,6 +122,7 @@ static void *create_config(apr_pool_t *p, server_rec *s)
   conf->root_enable = OFF;
   conf->cap_dac_override_enable = OFF;
   conf->keep_open_enable = OFF;
+  conf->psdav_enable = OFF;
   conf->extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->handlers = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
   conf->ignore_extensions = apr_array_make(p, PS_MAXEXTENSIONS, sizeof(char *));
@@ -254,6 +256,19 @@ static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)
   dconf->check_suexec_ids = flag;
 
   return NULL;
+}
+
+static const char *set_psdav_enable(cmd_parms *cmd, void *mconfig, int flag)
+{
+   process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+   const char *err = ap_check_cmd_context(cmd, NOT_IN_FILES | NOT_IN_LIMIT);
+
+   if (err != NULL)
+      return err;
+
+   conf->psdav_enable = flag;
+
+   return NULL;
 }
 
 static const char *set_extensions(cmd_parms *cmd, void *mconfig, const char *arg)
@@ -554,6 +569,8 @@ static const command_rec process_security_cmds[] = {
     AP_INIT_FLAG("PSCheckSuexecids", set_check_suexec_ids, NULL, ACCESS_CONF | RSRC_CONF,
                  "Set Enable Owner Check via suExecUserGgroup "
                  " On / Off. (default Off)"),
+    AP_INIT_FLAG("PSDavEnable", set_psdav_enable, NULL, ACCESS_CONF | RSRC_CONF,
+          "Set Enable working of considering webdav  On / Off. (default Off)"),
     AP_INIT_TAKE2("PSMinUidGid", set_minuidgid, NULL, RSRC_CONF, "Minimal uid and gid."),
     AP_INIT_TAKE2("PSDefaultUidGid", set_defuidgid, NULL, RSRC_CONF, "Default uid and gid."),
     AP_INIT_ITERATE("PSExtensions", set_extensions, NULL, ACCESS_CONF | RSRC_CONF, "Set Enable Extensions."),

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -46,6 +46,7 @@
 #include <sys/prctl.h>
 #include <sys/capability.h>
 #include <limits.h>
+#include "mod_process_security_dav.h"
 
 #define MODULE_NAME "mod_process_security"
 #define MODULE_VERSION "1.1.4"
@@ -300,6 +301,14 @@ static const char *set_psdav_enable(cmd_parms *cmd, void *mconfig, int flag)
    conf->psdav_enable = flag;
 
    return NULL;
+}
+
+static const dav_provider *dav_get_provider(request_rec *r)
+{
+   dav_dir_conf *conf;
+
+   conf = ap_get_module_config(r->per_dir_config, &dav_module);
+   return conf->provider;
 }
 
 static const char *set_extensions(cmd_parms *cmd, void *mconfig, const char *arg)

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -408,6 +408,10 @@ static int process_security_set_cap(request_rec *r)
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
 
   if(conf->psdav_enable && dav_get_provider(r)){
+     if(conf->dav_gid < 0 || conf->dav_uid < 0){
+         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "The webdav mode requires psdavuidgid parameters.");
+         return -1;
+     }
      gid = conf->dav_gid;
      uid = conf->dav_uid;
   }else{

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -191,28 +191,28 @@ static const char *set_defuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
 
 static const char *set_davuidgid(cmd_parms *cmd, void *mconfig, const char *uid, const char *gid)
 {
-   process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
-   unsigned long check_uid = (unsigned long)apr_atoi64(uid);
-   unsigned long check_gid = (unsigned long)apr_atoi64(gid);
-   const char *err = ap_check_cmd_context(cmd, NOT_IN_DIR_LOC_FILE | NOT_IN_LIMIT);
+  process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+  unsigned long check_uid = (unsigned long)apr_atoi64(uid);
+  unsigned long check_gid = (unsigned long)apr_atoi64(gid);
+  const char *err = ap_check_cmd_context(cmd, NOT_IN_DIR_LOC_FILE | NOT_IN_LIMIT);
 
-   if (err != NULL)
-      return err;
+  if (err != NULL)
+    return err;
 
-   if (check_uid > UINT_MAX) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defuid of illegal value", MODULE_NAME, __func__);
-      return "davuid of illegal value";
-   }
+  if (check_uid > UINT_MAX) {
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defuid of illegal value", MODULE_NAME, __func__);
+    return "davuid of illegal value";
+  }
 
-   if (check_gid > UINT_MAX) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defgid of illegal value", MODULE_NAME, __func__);
-      return "davgid of illegal value";
-   }
+  if (check_gid > UINT_MAX) {
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defgid of illegal value", MODULE_NAME, __func__);
+    return "davgid of illegal value";
+  }
 
-   conf->dav_uid = (uid_t)check_uid;
-   conf->dav_gid = (gid_t)check_gid;
+  conf->dav_uid = (uid_t)check_uid;
+  conf->dav_gid = (gid_t)check_gid;
 
-   return NULL;
+  return NULL;
 }
 
 static const char *set_all_ext(cmd_parms *cmd, void *mconfig, int flag)
@@ -291,23 +291,23 @@ static const char *set_check_suexec_ids(cmd_parms *cmd, void *mconfig, int flag)
 
 static const char *set_psdav_enable(cmd_parms *cmd, void *mconfig, int flag)
 {
-   process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
-   const char *err = ap_check_cmd_context(cmd, NOT_IN_FILES | NOT_IN_LIMIT);
+  process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+  const char *err = ap_check_cmd_context(cmd, NOT_IN_FILES | NOT_IN_LIMIT);
 
-   if (err != NULL)
-      return err;
+  if (err != NULL)
+    return err;
 
-   conf->psdav_enable = flag;
+  conf->psdav_enable = flag;
 
-   return NULL;
+  return NULL;
 }
 
 static const dav_provider *dav_get_provider(request_rec *r)
 {
-   dav_dir_conf *conf;
+  dav_dir_conf *conf;
 
-   conf = ap_get_module_config(r->per_dir_config, &dav_module);
-   return conf->provider;
+  conf = ap_get_module_config(r->per_dir_config, &dav_module);
+  return conf->provider;
 }
 
 static const char *set_extensions(cmd_parms *cmd, void *mconfig, const char *arg)
@@ -406,16 +406,16 @@ static int process_security_set_cap(request_rec *r)
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
 
-  if(conf->psdav_enable && dav_get_provider(r)){
-     if(conf->dav_gid < 0 || conf->dav_uid < 0){
-         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "The webdav mode requires psdavuidgid parameters.");
-         return -1;
-     }
-     gid = conf->dav_gid;
-     uid = conf->dav_uid;
-  }else{
-     gid = r->finfo.group;
-     uid = r->finfo.user;
+  if (conf->psdav_enable && dav_get_provider(r)) {
+    if (conf->dav_gid < 0 || conf->dav_uid < 0) {
+      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "The webdav mode requires psdavuidgid parameters.");
+      return -1;
+    }
+    gid = conf->dav_gid;
+    uid = conf->dav_uid;
+  } else {
+    gid = r->finfo.group;
+    uid = r->finfo.user;
   }
 
   if (!conf->root_enable && (uid == 0 || gid == 0)) {
@@ -516,57 +516,58 @@ static void *APR_THREAD_FUNC process_security_thread_handler(apr_thread_t *threa
 
 static int check_process_security_enable(request_rec *r, process_security_config_t *conf)
 {
-   char *extension;
-   const char *handler;
-   int enable = 0;
-   int name_len = 0;
-   int i;
+  char *extension;
+  const char *handler;
+  int enable = 0;
+  int name_len = 0;
+  int i;
 
-   if (conf->all_ext_enable) {
-      enable = ON;
-      for (i = 0; i < conf->ignore_extensions->nelts; i++) {
-         extension = ((char **)conf->ignore_extensions->elts)[i];
-         name_len = strlen(r->filename) - strlen(extension);
-         if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
-            enable = OFF;
-      }
-   } else {
-      for (i = 0; i < conf->extensions->nelts; i++) {
-         extension = ((char **)conf->extensions->elts)[i];
-         name_len = strlen(r->filename) - strlen(extension);
-         if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
-            enable = ON;
-      }
-      // check handler
-      for (i = 0; i < conf->handlers->nelts; i++) {
-         handler = ((char **)conf->handlers->elts)[i];
-         if (strcmp(r->handler, handler) == 0)
-            enable = ON;
-      }
-   }
+  if (conf->all_ext_enable) {
+    enable = ON;
+    for (i = 0; i < conf->ignore_extensions->nelts; i++) {
+      extension = ((char **)conf->ignore_extensions->elts)[i];
+      name_len = strlen(r->filename) - strlen(extension);
+      if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
+        enable = OFF;
+    }
+  } else {
+    for (i = 0; i < conf->extensions->nelts; i++) {
+      extension = ((char **)conf->extensions->elts)[i];
+      name_len = strlen(r->filename) - strlen(extension);
+      if (name_len >= 0 && strcmp(&r->filename[name_len], extension) == 0)
+        enable = ON;
+    }
+    // check handler
+    for (i = 0; i < conf->handlers->nelts; i++) {
+      handler = ((char **)conf->handlers->elts)[i];
+      if (strcmp(r->handler, handler) == 0)
+        enable = ON;
+    }
+  }
 
-   if (conf->all_cgi_enable && strcmp(r->handler, "cgi-script") == 0)
-      enable = ON;
+  if (conf->all_cgi_enable && strcmp(r->handler, "cgi-script") == 0)
+    enable = ON;
 
-   return enable;
+  return enable;
 }
 
 static int check_suexec_ids(request_rec *r)
 {
-   ap_unix_identity_t *ugid = ap_run_get_suexec_identity(r);
-   if (ugid == NULL) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-            "%s ERROR %s: PSCheckSuexecids failed return 500: ap_run_get_suexec_identity() is NULL or not found SuexecUserGroup",
-            MODULE_NAME, __func__);
-      return HTTP_INTERNAL_SERVER_ERROR;
-   }
-   if (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group) {
-      ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-            "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
-            MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
-      return HTTP_FORBIDDEN;
-   }
-   return APR_SUCCESS;
+  ap_unix_identity_t *ugid = ap_run_get_suexec_identity(r);
+  if (ugid == NULL) {
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s: PSCheckSuexecids failed return 500: "
+                                                 "ap_run_get_suexec_identity() is NULL or not found SuexecUserGroup",
+                 MODULE_NAME, __func__);
+    return HTTP_INTERNAL_SERVER_ERROR;
+  }
+  if (ugid->uid != r->finfo.user || ugid->gid != r->finfo.group) {
+    ap_log_error(
+        APLOG_MARK, APLOG_ERR, 0, NULL,
+        "%s ERROR %s: PSCheckSuexecids return 403: opened r->filename=%s uid=%d gid=%d but suexec config uid=%d gid=%d",
+        MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
+    return HTTP_FORBIDDEN;
+  }
+  return APR_SUCCESS;
 }
 
 static int process_security_handler(request_rec *r)
@@ -586,22 +587,22 @@ static int process_security_handler(request_rec *r)
     return DECLINED;
 
   // check process for standard mode
-  if(conf->psdav_enable == OFF || dav_get_provider(r) == NULL){
-     if (r->finfo.filetype == APR_NOFILE)
-        return DECLINED;
+  if (conf->psdav_enable == OFF || dav_get_provider(r) == NULL) {
+    if (r->finfo.filetype == APR_NOFILE)
+      return DECLINED;
 
-     enable = check_process_security_enable(r, conf);
+    enable = check_process_security_enable(r, conf);
 
-     if (!enable)
-        return DECLINED;
+    if (!enable)
+      return DECLINED;
 
-     // suexec ids check
-     if (dconf->check_suexec_ids == ON) {
-        check_suexec = check_suexec_ids(r);
-        if(check_suexec != APR_SUCCESS){
-           return check_suexec;
-        }
-     }
+    // suexec ids check
+    if (dconf->check_suexec_ids == ON) {
+      check_suexec = check_suexec_ids(r);
+      if (check_suexec != APR_SUCCESS) {
+        return check_suexec;
+      }
+    }
   }
 
   apr_threadattr_create(&thread_attr, r->pool);
@@ -641,7 +642,7 @@ static const command_rec process_security_cmds[] = {
                  "Set Enable Owner Check via suExecUserGgroup "
                  " On / Off. (default Off)"),
     AP_INIT_FLAG("PSDavEnable", set_psdav_enable, NULL, ACCESS_CONF | RSRC_CONF,
-          "Set Enable working of considering webdav  On / Off. (default Off)"),
+                 "Set Enable working of considering webdav  On / Off. (default Off)"),
     AP_INIT_TAKE2("PSMinUidGid", set_minuidgid, NULL, RSRC_CONF, "Minimal uid and gid."),
     AP_INIT_TAKE2("PSDefaultUidGid", set_defuidgid, NULL, RSRC_CONF, "Default uid and gid."),
     AP_INIT_TAKE2("PSDavUidGid", set_davuidgid, NULL, RSRC_CONF, "Webdav uid and gid."),
@@ -663,10 +664,11 @@ AP_DECLARE_MODULE(process_security) = {
 #else
 module AP_MODULE_DECLARE_DATA process_security_module = {
 #endif
-    STANDARD20_MODULE_STUFF, ps_create_dir_config, /* dir config creater */
-    NULL,                                          /* dir merger */
-    create_config,                                 /* server config */
-    NULL,                                          /* merge server config */
-    process_security_cmds,                         /* command apr_table_t */
-    register_hooks                                 /* register hooks */
+    STANDARD20_MODULE_STUFF,
+    ps_create_dir_config,  /* dir config creater */
+    NULL,                  /* dir merger */
+    create_config,         /* server config */
+    NULL,                  /* merge server config */
+    process_security_cmds, /* command apr_table_t */
+    register_hooks         /* register hooks */
 };

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -407,8 +407,13 @@ static int process_security_set_cap(request_rec *r)
 
   process_security_config_t *conf = ap_get_module_config(r->server->module_config, &process_security_module);
 
-  gid = r->finfo.group;
-  uid = r->finfo.user;
+  if(conf->psdav_enable && dav_get_provider(r)){
+     gid = conf->dav_gid;
+     uid = conf->dav_uid;
+  }else{
+     gid = r->finfo.group;
+     uid = r->finfo.user;
+  }
 
   if (!conf->root_enable && (uid == 0 || gid == 0)) {
     ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, NULL, "%s NOTICE %s: permission of %s is root, can't run the file",

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -192,19 +192,18 @@ static const char *set_defuidgid(cmd_parms *cmd, void *mconfig, const char *uid,
 static const char *set_davuidgid(cmd_parms *cmd, void *mconfig, const char *uid, const char *gid)
 {
    process_security_config_t *conf = ap_get_module_config(cmd->server->module_config, &process_security_module);
+   unsigned long check_uid = (unsigned long)apr_atoi64(uid);
+   unsigned long check_gid = (unsigned long)apr_atoi64(gid);
    const char *err = ap_check_cmd_context(cmd, NOT_IN_DIR_LOC_FILE | NOT_IN_LIMIT);
 
    if (err != NULL)
       return err;
-
-   unsigned long check_uid = (unsigned long)apr_atoi64(uid);
 
    if (check_uid > UINT_MAX) {
       ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defuid of illegal value", MODULE_NAME, __func__);
       return "davuid of illegal value";
    }
 
-   unsigned long check_gid = (unsigned long)apr_atoi64(gid);
    if (check_gid > UINT_MAX) {
       ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s:defgid of illegal value", MODULE_NAME, __func__);
       return "davgid of illegal value";

--- a/mod_process_security.c
+++ b/mod_process_security.c
@@ -566,7 +566,7 @@ static int check_suexec_ids(request_rec *r)
             MODULE_NAME, __func__, r->filename, r->finfo.user, r->finfo.group, ugid->uid, ugid->gid);
       return HTTP_FORBIDDEN;
    }
-   return 0;
+   return APR_SUCCESS;
 }
 
 static int process_security_handler(request_rec *r)
@@ -598,7 +598,7 @@ static int process_security_handler(request_rec *r)
      // suexec ids check
      if (dconf->check_suexec_ids == ON) {
         check_suexec = check_suexec_ids(r);
-        if(check_suexec != 0){
+        if(check_suexec != APR_SUCCESS){
            return check_suexec;
         }
      }

--- a/mod_process_security_dav.h
+++ b/mod_process_security_dav.h
@@ -1,3 +1,6 @@
+/*  This header file is necessary in order to mod_process_security 
+    get the directive structure of mod_dav.                         */
+
 #include "mod_dav.h"
 
 module DAV_DECLARE_DATA dav_module;
@@ -9,5 +12,4 @@ typedef struct {
    int locktimeout;
    int allow_depthinfinity;
 } dav_dir_conf;
-
 

--- a/mod_process_security_dav.h
+++ b/mod_process_security_dav.h
@@ -1,0 +1,13 @@
+#include "mod_dav.h"
+
+module DAV_DECLARE_DATA dav_module;
+
+typedef struct {
+   const char *provider_name;
+   const dav_provider *provider;
+   const char *dir;
+   int locktimeout;
+   int allow_depthinfinity;
+} dav_dir_conf;
+
+

--- a/test/lock.xml
+++ b/test/lock.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<lockinfo xmlns='DAV:'>
+ <lockscope><exclusive/></lockscope>
+<locktype><write/></locktype></lockinfo>

--- a/test/mod_process_security.dav.conf.2.2
+++ b/test/mod_process_security.dav.conf.2.2
@@ -1,0 +1,48 @@
+NameVirtualHost *:8080
+Listen 127.0.0.1:8080
+
+LoadModule dav_module modules/mod_dav.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule process_security_module modules/mod_process_security.so
+
+# for Webdav setting
+
+<VirtualHost *:8080>
+<IfModule mod_process_security.c>
+PSExAll On
+PSDavEnable On
+PSDavUidGid 1003 1003
+</IfModule>
+
+ServerAdmin webmaster@localhost
+DocumentRoot /usr/local/apache2/webdav/
+ServerName mps-webdav.test
+DAVLockDB /usr/local/apache2/webdav/.dav
+
+<Directory /usr/local/apache2/webdav>
+Order allow,deny
+Allow from all
+DAV ON
+</Directory>
+</VirtualHost>
+
+# for normal setting
+
+<VirtualHost *:8080>
+<IfModule mod_process_security.c>
+PSExAll On
+</IfModule>
+
+ServerAdmin webmaster@localhost
+DocumentRoot /usr/local/apache2/webdav/
+ServerName mps-normal.test
+
+<Directory /usr/local/apache2/webdav>
+Options ExecCGI
+AddHandler cgi-script .pl .cgi
+Order allow,deny
+Allow from all
+</Directory>
+</VirtualHost>
+

--- a/test/mod_process_security.dav.conf.2.2
+++ b/test/mod_process_security.dav.conf.2.2
@@ -12,7 +12,7 @@ LoadModule process_security_module modules/mod_process_security.so
 <IfModule mod_process_security.c>
 PSExAll On
 PSDavEnable On
-PSDavUidGid 1003 1003
+PSDavUidGid 1004 1004
 </IfModule>
 
 ServerAdmin webmaster@localhost

--- a/test/mod_process_security.dav.conf.2.4
+++ b/test/mod_process_security.dav.conf.2.4
@@ -1,0 +1,50 @@
+Listen 127.0.0.1:8080
+
+LoadModule dav_module modules/mod_dav.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule process_security_module modules/mod_process_security.so
+
+# for webdav setting
+
+<VirtualHost *:8080>
+<IfModule mod_process_security.c>
+PSExAll On
+PSDavEnable On
+PSDavUidGid 1003 1003
+</IfModule>
+
+ServerAdmin webmaster@localhost
+DocumentRoot /usr/local/apache2/webdav/
+ServerName mps-webdav.test
+DAVLockDB /usr/local/apache2/webdav/.dav
+
+KeepAlive On
+KeepAliveTimeout 3
+
+<Directory /usr/local/apache2/webdav>
+Require all granted
+Options ExecCGI
+AddHandler cgi-script .pl .cgi
+DAV ON
+</Directory>
+</VirtualHost>
+
+# for normal setting
+
+<VirtualHost *:8080>
+<IfModule mod_process_security.c>
+PSExAll On
+</IfModule>
+
+ServerAdmin webmaster@localhost
+DocumentRoot /usr/local/apache2/webdav/
+ServerName mps-normal.test
+
+<Directory /usr/local/apache2/webdav>
+Require all granted
+Options ExecCGI
+AddHandler cgi-script .pl .cgi
+</Directory>
+</VirtualHost>
+

--- a/test/mod_process_security.dav.conf.2.4
+++ b/test/mod_process_security.dav.conf.2.4
@@ -11,7 +11,7 @@ LoadModule process_security_module modules/mod_process_security.so
 <IfModule mod_process_security.c>
 PSExAll On
 PSDavEnable On
-PSDavUidGid 1003 1003
+PSDavUidGid 1004 1004
 </IfModule>
 
 ServerAdmin webmaster@localhost

--- a/test/userinfo.cgi
+++ b/test/userinfo.cgi
@@ -1,0 +1,6 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+print "Content-type: text/html; charset=utf-8\r\n\r\n";
+print "$<:$(";

--- a/test/userinfo.cgi
+++ b/test/userinfo.cgi
@@ -1,9 +1,10 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use FindBin qw($Bin $Script);
 
 my ($dev, $ino, $mode, $nlink, $uid, $gid, $rdev, $size,
-    $atime, $mtime, $ctime, $blksize, $blocks) = stat $fname;
+    $atime, $mtime, $ctime, $blksize, $blocks) = stat "$Bin/$Script";
 
 print "Content-type: text/html; charset=utf-8\r\n\r\n";
 print "$<:$(:$uid:$gid";

--- a/test/userinfo.cgi
+++ b/test/userinfo.cgi
@@ -2,5 +2,9 @@
 use strict;
 use warnings;
 
+my ($dev, $ino, $mode, $nlink, $uid, $gid, $rdev, $size,
+    $atime, $mtime, $ctime, $blksize, $blocks) = stat $fname;
+
 print "Content-type: text/html; charset=utf-8\r\n\r\n";
-print "$<:$(";
+print "$<:$(:$uid:$gid";
+


### PR DESCRIPTION
# 関連情報

 * https://github.com/matsumoto-r/mod_process_security/issues/14
 * https://github.com/matsumoto-r/mod_process_security/pull/16
 * https://github.com/matsumoto-r/mod_process_security/pull/17

# 対応手法

webdavはapacheのレスポンス生成時にmod_davに制御が移りmod_davの処理により機能が提供される。mod_process_securityはレスポンス生成時の一番早い段階に権限委譲を行うため、mod_davとの相性は良いが、mod_process_securityにはリクエストにより処理されるファイルのチェックやsuexecとの兼ね合いなどのチェックが入っており、既存のコードでは共存できない。

そこで既存のwebdavを考慮しないスタンダードモードと、webdavを考慮したwebdavモードに処理を分けて、webdavモード時にはファイルチェックやsuexecのチェックなどを行わないようにした。
さらに重要な点としてスタンダードモードだと最終的にアクセスされるファイルの所有権に権限委譲するが、webdavモードでは後述するPSDavUidGidで指定された権限で動作する。

本修正により、PSDavEnableとPSDavUidGidの2つのオプションが追加された。PSDavEnableはmod_process_securityのwebdavモードを適用するためのフラグであり、PSDavUidGidはmod_process_securityがwebdav関連の操作を行う時の権限移譲先のuidとgidである。

# Apacheの設定例

```
<VirtualHost *:80>
<IfModule mod_process_security.c>
PSExAll On
PSDavEnable On
PSDavUidGid 1001 1001
</IfModule>

ServerAdmin webmaster@localhost
DocumentRoot /var/www/webdav
ServerName mps-webdav.net
DAVLockDB /var/www/webdav/.dav

<Directory /var/www/webdav>
Require all granted
DAV On
</Directory>

</VirtualHost>
```

上記設定ではmps-webdav.netにwebdavクライアントがアクセスするとサーバ内の/var/www/webdavディレクトリ以下はwebdavで制御され、その際の権限はmod_process_securityによりuid,gid共に1001になる。

